### PR TITLE
fix bug in spectrogram cropping

### DIFF
--- a/lib/a2audio/recanalizer.py
+++ b/lib/a2audio/recanalizer.py
@@ -315,7 +315,7 @@ class Recanalizer:
         if i >= dims[0]:
             i = dims[0] - 1
 
-        Z= Pxx[(j-2):(i+2),:]
+        Z= Pxx[numpy.max([0, (j-2)]):numpy.min([(i+2), Pxx.shape[0]]),:]
 
         self.highIndex = dims[0]-j
         self.lowIndex = dims[0]-i


### PR DESCRIPTION
The bug was because the code adds and extra 2 frequency bins below and above the frequency band that is cropped out of a spectrogram, and it doesn't check for going below 0 or above the maximum frequency index when adding these extra bins. In the user's case, the index for the low bin was going below 0 after subtracting 2 from 1, and then the spectrogram was coming out empty.