### PR TITLE
fix MySQL error status write

### DIFF
--- a/scripts/PatternMatching/train.py
+++ b/scripts/PatternMatching/train.py
@@ -62,7 +62,6 @@ def exit_error(db, workingFolder, log, jobId, msg):
             UPDATE `jobs`
             SET `remarks` = %s,
                 `state`="error",
-                `progress` = `progress_steps`,
                 `completed` = 1 ,
                 `last_update` = now()
             WHERE `job_id` = %s


### PR DESCRIPTION
The Random Forest training script in `scripts/PatternMatching/train.py` had a function `exit_error()`. This function had a bug where it changed the `progress` (current job progress) column of the job to `progress_steps` (total number of progress steps in the job). It also changed the job `state` to `error`, however, a database trigger exists to change job `state=completed` when `progress==progress_steps`, so this was overriding the `error` status.