### PR TITLE
CE-648 Remove references to legacy column on site

### DIFF
--- a/lib/a2audio/classification_lib.py
+++ b/lib/a2audio/classification_lib.py
@@ -80,9 +80,8 @@ def get_playlist(db,playlistId,log):
         recsToClassify = []
         with contextlib.closing(db.cursor()) as cursor:
             cursor.execute("""
-                SELECT r.`recording_id`, r.`uri`, s.legacy
+                SELECT r.`recording_id`, r.`uri`, IF(LEFT(r.uri, 8) = 'project_', 1, 0) legacy
                 FROM `recordings` r JOIN `playlist_recordings` pr ON r.`recording_id` = pr.`recording_id`
-                JOIN `sites` s ON r.`site_id` = s.`site_id`
                 WHERE pr.`playlist_id` = %s
             """, [playlistId])
             db.commit()

--- a/scripts/PatternMatching/train.py
+++ b/scripts/PatternMatching/train.py
@@ -142,10 +142,9 @@ if model_type_id in [4]:
             # create training file
             cursor.execute("""
                 SELECT r.`recording_id`, ts.`species_id`, ts.`songtype_id`,
-                    ts.`x1`, ts.`x2`, ts.`y1`, ts.`y2`, r.`uri`, s.`legacy`
+                    ts.`x1`, ts.`x2`, ts.`y1`, ts.`y2`, r.`uri`, IF(LEFT(r.uri, 8) = 'project_', 1, 0) legacy
                 FROM `training_set_roi_set_data` ts
                   JOIN `recordings` r ON r.`recording_id` = ts.`recording_id`
-                  JOIN `sites` s ON r.`site_id` = s.`site_id`
                 WHERE ts.`training_set_id` = %s
             """, [training_set_id])
             db.commit()
@@ -220,10 +219,9 @@ if model_type_id in [4]:
                 with closing(db.cursor()) as cursor:
                     cursor.execute(
                         """
-                        (SELECT r.`uri` , `species_id` , `songtype_id` , `present` , r.`recording_id`, s.`legacy`
+                        (SELECT r.`uri` , `species_id` , `songtype_id` , `present` , r.`recording_id`, IF(LEFT(r.uri, 8) = 'project_', 1, 0) legacy
                         FROM `recording_validations` rv 
                           JOIN `recordings` r ON r.`recording_id` = rv.`recording_id`
-                          JOIN `sites` s ON r.`site_id` = s.`site_id`
                         WHERE rv.`project_id` = %s
                           AND `species_id` = %s
                           AND `songtype_id` = %s
@@ -231,10 +229,9 @@ if model_type_id in [4]:
                           ORDER BY rand()
                           LIMIT %s)
                           UNION
-                        (SELECT r.`uri` , `species_id` , `songtype_id` , `present` , r.`recording_id`, s.`legacy`
+                        (SELECT r.`uri` , `species_id` , `songtype_id` , `present` , r.`recording_id`, IF(LEFT(r.uri, 8) = 'project_', 1, 0) legacy
                         FROM `recording_validations` rv 
                           JOIN `recordings` r ON r.`recording_id` = rv.`recording_id`
-                          JOIN `sites` s ON r.`site_id` = s.`site_id`
                         WHERE rv.`project_id` = %s
                           AND `species_id` = %s
                           AND `songtype_id` = %s

--- a/scripts/Soundscapes/playlist2soundscape.py
+++ b/scripts/Soundscapes/playlist2soundscape.py
@@ -135,10 +135,9 @@ awsSecretKey = config[9]
 try:
     #------------------------------- PREPARE --------------------------------------------------------------------------------------------------------------------
     q = ("SELECT r.`recording_id`,`uri`, DATE_FORMAT( `datetime` , \
-        '%Y-%m-%d %H:%i:%s') as date, s.legacy \
+        '%Y-%m-%d %H:%i:%s') as date, IF(LEFT(r.uri, 8) = 'project_', 1, 0) legacy \
         FROM `playlist_recordings` pr \
         JOIN `recordings` r ON pr.`recording_id` = r.`recording_id` \
-        JOIN `sites` s ON r.`site_id` = s.`site_id` \
         WHERE `playlist_id` = " + str(playlist_id))
 
     log.write('retrieving playlist recordings list')


### PR DESCRIPTION
This change solves two problems:
- the `legacy` column is incorrectly set on many sites
- it's possible that some sites have audio uploaded via web and Uploader (which previously would break the jobs)

After this change, there should be no references to the legacy sites column and therefore it can be deleted (planned for next sprint [CE-719](https://jira.rfcx.org/browse/CE-719)).