### PR TITLE
Jack resampling fix

### DIFF
--- a/lib/a2audio/filters/resample_poly_filter.py
+++ b/lib/a2audio/filters/resample_poly_filter.py
@@ -41,8 +41,8 @@ def resample_poly_filter_window(up, down, beta=5.0, L=16001):
 def resample_poly_filter(data, current_sample_rate, new_sample_rate):
     "Resamples a 1d array from a current_sample_rate to a new_sample_rate using resample_poly_filter"
     
-		if new_sample_rate in (current_sample_rate*2, current_sample_rate/2):
-				new_sample_rate+=1
+    if new_sample_rate in (current_sample_rate*2, current_sample_rate/2):
+        new_sample_rate+=1
 
 		# Create a filter for resampling
     window = resample_poly_filter_window(new_sample_rate, current_sample_rate)


### PR DESCRIPTION
There is an obscure issue with the resampling code where if the new sample rate is 2X or 0.5X the original, an error would be thrown. This is a temporary fix for this case, by incrementing the new sample rate by 1 in these cases. I would have to look deeper into the scipy "firwin" function to understand the error.

There is also a new file that I added during Soundscape testing.